### PR TITLE
Corrected parameter to socket resource destructor call.

### DIFF
--- a/mosquitto.c
+++ b/mosquitto.c
@@ -869,7 +869,7 @@ static void mosquitto_client_object_destroy(void *object TSRMLS_DC)
 	}
 
 	if (client->socket_zval != NULL) {
-		zval_ptr_dtor(client->socket_zval);
+		zval_ptr_dtor(&(client->socket_zval));
 	}
 
 	PHP_MOSQUITTO_FREE_CALLBACK(connect);


### PR DESCRIPTION
I have finally got around to test the refcount solution and it seems to work in my tests.
The compiler warned about a wrong parameter type so I have changed the destructor call slightly.

It is now possible to use the return value from getSocket in php socket calls, like socket_select.
It also works with reactphp, using libevent as engine.
