### PR TITLE
PHP7 Compat

### DIFF
--- a/mosquitto_message.c
+++ b/mosquitto_message.c
@@ -14,6 +14,15 @@ zend_class_entry *mosquitto_ce_message;
 static zend_object_handlers mosquitto_message_object_handlers;
 static HashTable php_mosquitto_message_properties;
 
+#ifdef ZEND_ENGINE_3
+typedef size_t mosquitto_strlen_type;
+#else
+# ifndef Z_OBJ_P
+#  define Z_OBJ_P(pzv) ((zend_object*)zend_object_store_get_object(pzv TSRMLS_CC))
+# endif
+typedef int mosquitto_strlen_type;
+#endif
+
 /* {{{ Arginfo */
 
 ZEND_BEGIN_ARG_INFO(Mosquitto_Message_topicMatchesSub_args, ZEND_SEND_BY_VAL)
@@ -41,7 +50,7 @@ PHP_METHOD(Mosquitto_Message, __construct)
 PHP_METHOD(Mosquitto_Message, topicMatchesSub)
 {
 	char *topic = NULL, *subscription = NULL;
-	int topic_len, subscription_len;
+	mosquitto_strlen_type topic_len, subscription_len;
 	zend_bool result;
 
 	PHP_MOSQUITTO_ERROR_HANDLING();
@@ -61,7 +70,7 @@ PHP_METHOD(Mosquitto_Message, topicMatchesSub)
 PHP_METHOD(Mosquitto_Message, tokeniseTopic)
 {
 	char *topic = NULL, **topics = NULL;
-	int topic_len = 0, retval = 0, count = 0, i = 0;
+	mosquitto_strlen_type topic_len = 0, retval = 0, count = 0, i = 0;
 
 	PHP_MOSQUITTO_ERROR_HANDLING();
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &topic, &topic_len) == FAILURE) {
@@ -70,7 +79,7 @@ PHP_METHOD(Mosquitto_Message, tokeniseTopic)
 	}
 	PHP_MOSQUITTO_RESTORE_ERRORS();
 
-	retval = mosquitto_sub_topic_tokenise(topic, &topics, &count);
+	retval = mosquitto_sub_topic_tokenise(topic, &topics, (int*)&count);
 
 	if (retval == MOSQ_ERR_NOMEM) {
 		zend_throw_exception_ex(mosquitto_ce_exception, 0 TSRMLS_CC, "Failed to tokenise topic");
@@ -82,7 +91,11 @@ PHP_METHOD(Mosquitto_Message, tokeniseTopic)
 		if (topics[i] == NULL) {
 			add_next_index_null(return_value);
 		} else {
+#ifdef ZEND_ENGINE_3
+			add_next_index_string(return_value, topics[i]);
+#else
 			add_next_index_string(return_value, topics[i], 1);
+#endif
 		}
 	}
 
@@ -93,6 +106,30 @@ PHP_METHOD(Mosquitto_Message, tokeniseTopic)
 PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_READER_FUNCTION(mid);
 PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_READER_FUNCTION(qos);
 
+#ifdef ZEND_ENGINE_3
+static int php_mosquitto_message_read_retain(mosquitto_message_object *mosquitto_object, zval *retval)
+{
+	ZVAL_BOOL(retval, mosquitto_object->message.retain);
+	return SUCCESS;
+}
+
+static int php_mosquitto_message_read_topic(mosquitto_message_object *mosquitto_object, zval *retval)
+{
+	if (mosquitto_object->message.topic != NULL) {
+		ZVAL_STRING(retval, mosquitto_object->message.topic);
+	} else {
+		ZVAL_NULL(retval);
+	}
+
+	return SUCCESS;
+}
+
+static int php_mosquitto_message_read_payload(mosquitto_message_object *mosquitto_object, zval *retval)
+{
+	ZVAL_STRINGL(retval, mosquitto_object->message.payload, mosquitto_object->message.payloadlen);
+	return SUCCESS;
+}
+#else
 static int php_mosquitto_message_read_retain(mosquitto_message_object *mosquitto_object, zval **retval TSRMLS_DC)
 {
 	MAKE_STD_ZVAL(*retval);
@@ -105,7 +142,7 @@ static int php_mosquitto_message_read_topic(mosquitto_message_object *mosquitto_
 	MAKE_STD_ZVAL(*retval);
 
 	if (mosquitto_object->message.topic != NULL) {
-		ZVAL_STRINGL(*retval, mosquitto_object->message.topic, strlen(mosquitto_object->message.topic), 1);
+		ZVAL_STRING(*retval, mosquitto_object->message.topic, 1);
 	} else {
 		ZVAL_NULL(*retval);
 	}
@@ -119,25 +156,14 @@ static int php_mosquitto_message_read_payload(mosquitto_message_object *mosquitt
 	ZVAL_STRINGL(*retval, mosquitto_object->message.payload, mosquitto_object->message.payloadlen, 1);
 	return SUCCESS;
 }
+#endif
 
 PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_WRITER_FUNCTION(mid);
 PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_WRITER_FUNCTION(qos);
 
 static int php_mosquitto_message_write_retain(mosquitto_message_object *mosquitto_object, zval *newval TSRMLS_DC)
 {
-	zval ztmp;
-	if (Z_TYPE_P(newval) != IS_BOOL) {
-		ztmp = *newval;
-		zval_copy_ctor(&ztmp);
-		convert_to_boolean(&ztmp);
-		newval = &ztmp;
-	}
-
-	mosquitto_object->message.retain = Z_LVAL_P(newval);
-
-	if (newval == &ztmp) {
-		zval_dtor(newval);
-	}
+	mosquitto_object->message.retain = zend_is_true(newval);
 
 	return SUCCESS;
 }
@@ -201,15 +227,45 @@ const php_mosquitto_prop_handler php_mosquitto_message_property_entries[] = {
 	{NULL, 0, NULL, NULL}
 };
 
-zval *php_mosquitto_message_read_property(zval *object, zval *member, int type ZEND_LITERAL_KEY_DC TSRMLS_DC)
-{
-	zval tmp_member;
-	zval *retval;
-	mosquitto_message_object *message_object;
-	php_mosquitto_prop_handler *hnd;
-	int ret;
+#ifdef ZEND_ENGINE_3
+# define READ_PROPERTY_DC , void **cache_slot, zval *retval
+# define READ_PROPERTY_CC , cache_slot, retval
+# define WRITE_PROPERTY_DC , void **cache_slot
+# define WRITE_PROPERTY_CC , cache_slot
+# define HAS_PROPERTY_DC , void **cache_slot
+# define HAS_PROPERTY_CC , cache_slot
 
-	message_object = (mosquitto_message_object *) zend_object_store_get_object(object TSRMLS_CC);
+static php_mosquitto_prop_handler *mosquitto_get_prop_handler(zval *prop) {
+	zval *ret = zend_hash_find(&php_mosquitto_message_properties, Z_STR_P(prop));
+	if (!ret || Z_TYPE_P(ret) != IS_PTR) {
+		return NULL;
+	}
+	return (php_mosquitto_prop_handler*)Z_PTR_P(ret);
+}
+#else
+# define READ_PROPERTY_DC ZEND_LITERAL_KEY_DC TSRMLS_DC
+# define READ_PROPERTY_CC ZEND_LITERAL_KEY_CC TSRMLS_CC
+# define WRITE_PROPERTY_DC ZEND_LITERAL_KEY_DC TSRMLS_DC
+# define WRITE_PROPERTY_CC ZEND_LITERAL_KEY_CC TSRMLS_CC
+# define HAS_PROPERTY_DC ZEND_LITERAL_KEY_DC TSRMLS_DC
+# define HAS_PROPERTY_CC ZEND_LITERAL_KEY_CC TSRMLS_CC
+
+static php_mosquitto_prop_handler *mosquitto_get_prop_handler(zval *prop) {
+	php_mosquitto_prop_handler *hnd;
+	if (FAILURE == zend_hash_find(&php_mosquitto_message_properties, Z_STRVAL_P(prop), Z_STRLEN_P(prop)+1, (void**) &hnd)) {
+		return NULL;
+	}
+	return hnd;
+}
+#endif
+
+zval *php_mosquitto_message_read_property(zval *object, zval *member, int type READ_PROPERTY_DC) {
+	zval tmp_member;
+#ifndef ZEND_ENGINE_3
+	zval *retval;
+#endif
+	mosquitto_message_object *message_object = mosquitto_message_object_from_zend_object(Z_OBJ_P(object));
+	php_mosquitto_prop_handler *hnd;
 
 	if (Z_TYPE_P(member) != IS_STRING) {
 		tmp_member = *member;
@@ -217,20 +273,24 @@ zval *php_mosquitto_message_read_property(zval *object, zval *member, int type Z
 		convert_to_string(&tmp_member);
 		member = &tmp_member;
 	}
+	hnd = mosquitto_get_prop_handler(member);
 
-	ret = zend_hash_find(&php_mosquitto_message_properties, Z_STRVAL_P(member), Z_STRLEN_P(member)+1, (void **) &hnd);
-
-	if (ret == SUCCESS && hnd->read_func) {
-		ret = hnd->read_func(message_object, &retval TSRMLS_CC);
-		if (ret == SUCCESS) {
+	if (hnd && hnd->read_func) {
+#ifdef ZEND_ENGINE_3
+		if (FAILURE == hnd->read_func(message_object, retval)) {
+			ZVAL_NULL(retval);
+		}
+#else
+		if (SUCCESS == hnd->read_func(message_object, &retval TSRMLS_CC)) {
 			/* ensure we're creating a temporary variable */
 			Z_SET_REFCOUNT_P(retval, 0);
 		} else {
 			retval = EG(uninitialized_zval_ptr);
 		}
+#endif
 	} else {
 		zend_object_handlers * std_hnd = zend_get_std_object_handlers();
-		retval = std_hnd->read_property(object, member, type ZEND_LITERAL_KEY_CC TSRMLS_CC);
+		retval = std_hnd->read_property(object, member, type READ_PROPERTY_CC);
 	}
 
 	if (member == &tmp_member) {
@@ -240,12 +300,11 @@ zval *php_mosquitto_message_read_property(zval *object, zval *member, int type Z
 	return(retval);
 }
 
-void php_mosquitto_message_write_property(zval *object, zval *member, zval *value ZEND_LITERAL_KEY_DC TSRMLS_DC)
+void php_mosquitto_message_write_property(zval *object, zval *member, zval *value WRITE_PROPERTY_DC)
 {
 	zval tmp_member;
-	mosquitto_message_object *obj;
+	mosquitto_message_object *obj = mosquitto_message_object_from_zend_object(Z_OBJ_P(object));
 	php_mosquitto_prop_handler *hnd;
-	int ret;
 
 	if (Z_TYPE_P(member) != IS_STRING) {
 		tmp_member = *member;
@@ -254,20 +313,24 @@ void php_mosquitto_message_write_property(zval *object, zval *member, zval *valu
 		member = &tmp_member;
 	}
 
-	ret = FAILURE;
-	obj = (mosquitto_message_object *)zend_objects_get_address(object TSRMLS_CC);
+	hnd = mosquitto_get_prop_handler(member);
 
-	ret = zend_hash_find(&php_mosquitto_message_properties, Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void **) &hnd);
-
-	if (ret == SUCCESS && hnd->write_func) {
+	if (hnd && hnd->write_func) {
 		hnd->write_func(obj, value TSRMLS_CC);
+#ifdef ZEND_ENGINE_3
+		if (Z_REFCOUNTED_P(value)) {
+			Z_ADDREF_P(value);
+			zval_ptr_dtor(value);
+		}
+#else
 		if (! PZVAL_IS_REF(value) && Z_REFCOUNT_P(value) == 0) {
 			Z_ADDREF_P(value);
 			zval_ptr_dtor(&value);
 		}
+#endif
 	} else {
 		zend_object_handlers * std_hnd = zend_get_std_object_handlers();
-		std_hnd->write_property(object, member, value ZEND_LITERAL_KEY_CC TSRMLS_CC);
+		std_hnd->write_property(object, member, value WRITE_PROPERTY_CC);
 	}
 
 	if (member == &tmp_member) {
@@ -275,28 +338,45 @@ void php_mosquitto_message_write_property(zval *object, zval *member, zval *valu
 	}
 }
 
-static int php_mosquitto_message_has_property(zval *object, zval *member, int has_set_exists ZEND_LITERAL_KEY_DC TSRMLS_DC)
+static int php_mosquitto_message_has_property(zval *object, zval *member, int has_set_exists HAS_PROPERTY_DC)
 {
-	php_mosquitto_prop_handler *hnd;
+	php_mosquitto_prop_handler *hnd = mosquitto_get_prop_handler(member);
 	int ret = 0;
+#ifdef ZEND_ENGINE_3
+	zval rv;
+	zval *retval = &rv;
+#endif
 
-	if (zend_hash_find(&php_mosquitto_message_properties, Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void **)&hnd) == SUCCESS) {
+	if (hnd) {
 		switch (has_set_exists) {
 			case 2:
 				ret = 1;
 				break;
 			case 0: {
-				zval *value = php_mosquitto_message_read_property(object, member, BP_VAR_IS ZEND_LITERAL_KEY_CC TSRMLS_CC);
+				zval *value = php_mosquitto_message_read_property(object, member, BP_VAR_IS READ_PROPERTY_CC);
+#ifdef ZEND_ENGINE_3
+				if (Z_REFCOUNTED_P(value)) {
+					Z_ADDREF_P(value);
+					zval_ptr_dtor(value);
+				}
+#else
 				if (value != EG(uninitialized_zval_ptr)) {
 					ret = Z_TYPE_P(value) != IS_NULL? 1:0;
 					/* refcount is 0 */
 					Z_ADDREF_P(value);
 					zval_ptr_dtor(&value);
 				}
+#endif
 				break;
 			}
 			default: {
-				zval *value = php_mosquitto_message_read_property(object, member, BP_VAR_IS ZEND_LITERAL_KEY_CC TSRMLS_CC);
+				zval *value = php_mosquitto_message_read_property(object, member, BP_VAR_IS READ_PROPERTY_CC);
+#ifdef ZEND_ENGINE_3
+				if (Z_REFCOUNTED_P(value)) {
+					Z_ADDREF_P(value);
+					zval_ptr_dtor(value);
+				}
+#else
 				if (value != EG(uninitialized_zval_ptr)) {
 					convert_to_boolean(value);
 					ret = Z_BVAL_P(value)? 1:0;
@@ -304,59 +384,109 @@ static int php_mosquitto_message_has_property(zval *object, zval *member, int ha
 					Z_ADDREF_P(value);
 					zval_ptr_dtor(&value);
 				}
+#endif
 				break;
 			}
 		}
 	} else {
 		zend_object_handlers * std_hnd = zend_get_std_object_handlers();
-		ret = std_hnd->has_property(object, member, has_set_exists ZEND_LITERAL_KEY_CC TSRMLS_CC);
+		ret = std_hnd->has_property(object, member, has_set_exists HAS_PROPERTY_CC);
 	}
 	return ret;
 }
 
+#ifndef ZEND_ENGINE_3
+# ifndef ZEND_HASH_FOREACH_PTR
+#  define ZEND_HASH_FOREACH_KEY_PTR(ht, idx, key, ptr) \
+   { \
+     HashPosition pos; \
+     for (zend_hash_internal_pointer_reset_ex(ht, &pos); \
+          zend_hash_get_current_data_ex(ht, (void**)&ptr, &pos) == SUCCESS; \
+          zend_hash_move_forward_ex(ht, &pos)) { \
+       key = NULL; \
+       zend_hash_get_current_key_ex(ht, &key, &key##_len, &idx, 0, &pos); \
+       {
+# endif
+# ifndef ZEND_HASH_FOREACH_END
+#  define ZEND_HASH_FOREACH_END() \
+       } \
+     } \
+   }
+# endif
+#endif
+
 static HashTable *php_mosquitto_message_get_properties(zval *object TSRMLS_DC)
 {
-	mosquitto_message_object *obj;
+	mosquitto_message_object *obj = mosquitto_message_object_from_zend_object(Z_OBJ_P(object));
 	php_mosquitto_prop_handler *hnd;
 	HashTable *props;
-	zval *val;
+#ifdef ZEND_ENGINE_3
+	zend_string *key;
+	zend_long num_key;
+#else
 	char *key;
 	uint key_len;
-	HashPosition pos;
 	ulong num_key;
+#endif
 
-	obj = (mosquitto_message_object *)zend_objects_get_address(object TSRMLS_CC);
 	props = zend_std_get_properties(object TSRMLS_CC);
 
-	zend_hash_internal_pointer_reset_ex(&php_mosquitto_message_properties, &pos);
-
-	while (zend_hash_get_current_data_ex(&php_mosquitto_message_properties, (void**)&hnd, &pos) == SUCCESS) {
-		zend_hash_get_current_key_ex(&php_mosquitto_message_properties, &key, &key_len, &num_key, 0, &pos);
+	ZEND_HASH_FOREACH_KEY_PTR(&php_mosquitto_message_properties, num_key, key, hnd) {
+#ifdef ZEND_ENGINE_3
+		zval val;
+		if (!hnd->read_func || (hnd->read_func(obj, &val) != SUCCESS)) {
+			ZVAL_NULL(&val);
+		}
+		if (key) {
+			zend_hash_update(props, key, &val);
+		} else {
+			zend_hash_index_update(props, num_key, &val);
+		}
+#else
+		zval *val;
 		if (!hnd->read_func || hnd->read_func(obj, &val TSRMLS_CC) != SUCCESS) {
 			val = EG(uninitialized_zval_ptr);
 			Z_ADDREF_P(val);
 		}
-		zend_hash_update(props, key, key_len, (void *)&val, sizeof(zval *), NULL);
-		zend_hash_move_forward_ex(&php_mosquitto_message_properties, &pos);
-	}
+		if (key) {
+			zend_hash_update(props, key, key_len, (void *)&val, sizeof(zval*), NULL);
+        } else {
+			zend_hash_index_update(props, num_key, (void *)&val, sizeof(zval*), NULL);
+        }
+#endif
+	} ZEND_HASH_FOREACH_END();
+
 	return obj->std.properties;
 }
 
 
 void php_mosquitto_message_add_property(HashTable *h, const char *name, size_t name_length, php_mosquitto_read_t read_func, php_mosquitto_write_t write_func TSRMLS_DC)
 {
-	php_mosquitto_prop_handler p;
+#ifdef ZEND_ENGINE_3
+	php_mosquitto_prop_handler *p = (php_mosquitto_prop_handler*)pemalloc(sizeof(php_mosquitto_prop_handler), 1);
+#else
+	php_mosquitto_prop_handler val, *p = &val;
+#endif
 
-	p.name = (char*) name;
-	p.name_length = name_length;
-	p.read_func = (read_func) ? read_func : NULL;
-	p.write_func = (write_func) ? write_func : NULL;
-	zend_hash_add(h, (char *)name, name_length + 1, &p, sizeof(php_mosquitto_prop_handler), NULL);
+	p->name = (char*) name;
+	p->name_length = name_length;
+	p->read_func = read_func;
+	p->write_func = write_func;
+#ifdef ZEND_ENGINE_3
+	{
+		zend_string *key = zend_string_init(name, name_length, 1);
+		zval hnd;
+		ZVAL_PTR(&hnd, p);
+		zend_hash_add(h, key, &hnd);
+	}
+#else
+	zend_hash_add(h, (char *)name, name_length + 1, p, sizeof(php_mosquitto_prop_handler), NULL);
+#endif
 }
 
-static void mosquitto_message_object_destroy(void *object TSRMLS_DC)
+static void mosquitto_message_object_destroy(zend_object *object TSRMLS_DC)
 {
-	mosquitto_message_object *message = (mosquitto_message_object *) object;
+	mosquitto_message_object *message = mosquitto_message_object_from_zend_object(object);
 	zend_hash_destroy(message->std.properties);
 	FREE_HASHTABLE(message->std.properties);
 
@@ -371,6 +501,21 @@ static void mosquitto_message_object_destroy(void *object TSRMLS_DC)
 	efree(object);
 }
 
+#ifdef ZEND_ENGINE_3
+static zend_object *mosquitto_message_object_new(zend_class_entry *ce) {
+	mosquitto_message_object *msg = ecalloc(1, sizeof(mosquitto_message_object) + zend_object_properties_size(ce));
+	zend_object *ret = mosquitto_message_object_to_zend_object(msg);
+
+#ifdef MOSQUITTO_NEED_TSRMLS
+	message_obj->TSRMLS_C = TSRMLS_C;
+#endif
+
+	zend_object_std_init(ret, ce);
+	ret->handlers = &mosquitto_message_object_handlers;
+
+	return ret;
+}
+#else
 static zend_object_value mosquitto_message_object_new(zend_class_entry *ce TSRMLS_DC) {
 
 	zend_object_value retval;
@@ -382,7 +527,7 @@ static zend_object_value mosquitto_message_object_new(zend_class_entry *ce TSRML
 	message_obj = ecalloc(1, sizeof(mosquitto_message_object));
 	message_obj->std.ce = ce;
 
-#ifdef ZTS
+#ifdef MOSQUITTO_NEED_TSRMLS
 	message_obj->TSRMLS_C = TSRMLS_C;
 #endif
 
@@ -397,6 +542,7 @@ static zend_object_value mosquitto_message_object_new(zend_class_entry *ce TSRML
 	retval.handlers = &mosquitto_message_object_handlers;
 	return retval;
 }
+#endif
 
 const zend_function_entry mosquitto_message_methods[] = {
 	PHP_ME(Mosquitto_Message, __construct, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
@@ -413,6 +559,10 @@ PHP_MINIT_FUNCTION(mosquitto_message)
 	mosquitto_message_object_handlers.write_property = php_mosquitto_message_write_property;
 	mosquitto_message_object_handlers.has_property = php_mosquitto_message_has_property;
 	mosquitto_message_object_handlers.get_properties = php_mosquitto_message_get_properties;
+#ifdef ZEND_ENGINE_3
+    mosquitto_message_object_handlers.offset    = XtOffsetOf(mosquitto_message_object, std);
+    mosquitto_message_object_handlers.free_obj  = mosquitto_message_object_destroy;
+#endif
 
 	INIT_NS_CLASS_ENTRY(message_ce, "Mosquitto", "Message", mosquitto_message_methods);
 	mosquitto_ce_message = zend_register_internal_class(&message_ce TSRMLS_CC);

--- a/php_mosquitto.h
+++ b/php_mosquitto.h
@@ -36,8 +36,14 @@ extern zend_module_entry mosquitto_module_entry;
 
 #include <mosquitto.h>
 
+#if defined(ZEND_ENGINE_2) && defined(ZTS)
+# define MOSQUITTO_NEED_TSRMLS
+#endif
+
 typedef struct _mosquitto_client_object {
+#ifndef ZEND_ENGINE_3
 	zend_object std;
+#endif
 	struct mosquitto *client;
 
 	zend_fcall_info connect_callback;
@@ -55,24 +61,60 @@ typedef struct _mosquitto_client_object {
 	zend_fcall_info log_callback;
 	zend_fcall_info_cache log_callback_cache;
 
-    int looping;
+	int looping;
 
-#ifdef ZTS
+#ifdef MOSQUITTO_NEED_TSRMLS
 	TSRMLS_D;
+#endif
+#ifdef ZEND_ENGINE_3
+	zend_object std; /* Must be last */
 #endif
 } mosquitto_client_object;
 
 typedef struct _mosquitto_message_object {
+#ifndef ZEND_ENGINE_3
 	zend_object std;
+#endif
 	struct mosquitto_message message;
 	zend_bool owned_topic;
 	zend_bool owned_payload;
-#ifdef ZTS
+#ifdef MOSQUITTO_NEED_TSRMLS
 	TSRMLS_D;
+#endif
+#ifdef ZEND_ENGINE_3
+	zend_object std; /* Must be last */
 #endif
 } mosquitto_message_object;
 
+static inline
+mosquitto_client_object *mosquitto_client_object_from_zend_object(zend_object* obj) {
+	return (mosquitto_client_object*)(
+		((char*)obj) - XtOffsetOf(mosquitto_client_object, std)
+	);
+}
+
+static inline
+zend_object *mosquitto_client_object_to_zend_object(mosquitto_client_object* client) {
+	return &(client->std);
+}
+
+static inline
+mosquitto_message_object *mosquitto_message_object_from_zend_object(zend_object* obj) {
+	return (mosquitto_message_object*)(
+		((char*)obj) - XtOffsetOf(mosquitto_message_object, std)
+	);
+}
+
+static inline
+zend_object *mosquitto_message_object_to_zend_object(mosquitto_message_object* msg) {
+	return &(msg->std);
+}
+
+#ifdef ZEND_ENGINE_3
+typedef int (*php_mosquitto_read_t)(mosquitto_message_object *mosquitto_object, zval *retval);
+#else
 typedef int (*php_mosquitto_read_t)(mosquitto_message_object *mosquitto_object, zval **retval TSRMLS_DC);
+#endif
 typedef int (*php_mosquitto_write_t)(mosquitto_message_object *mosquitto_object, zval *newval TSRMLS_DC);
 
 typedef struct _php_mosquitto_prop_handler {
@@ -89,16 +131,31 @@ typedef struct _php_mosquitto_prop_handler {
 #define PHP_MOSQUITTO_RESTORE_ERRORS() \
 	zend_restore_error_handling(&MQTTG(mosquitto_original_error_handling) TSRMLS_CC)
 
-
-#define PHP_MOSQUITTO_FREE_CALLBACK(CALLBACK) \
+#ifdef ZEND_ENGINE_3
+# define PHP_MOSQUITTO_FREE_CALLBACK(client, CALLBACK) \
+    if (ZEND_FCI_INITIALIZED(client->CALLBACK ## _callback)) { \
+        zval_ptr_dtor(&client->CALLBACK ## _callback.function_name); \
+    } \
+ \
+    if (client->CALLBACK ## _callback.object != NULL) { \
+		zval tmp_; \
+		ZVAL_OBJ(&tmp_, client->CALLBACK ## _callback.object); \
+		zval_ptr_dtor(&tmp_); \
+    } \
+	client->CALLBACK ## _callback = empty_fcall_info; \
+	client->CALLBACK ## _callback_cache = empty_fcall_info_cache;
+#else
+# define PHP_MOSQUITTO_FREE_CALLBACK(client, CALLBACK) \
     if (ZEND_FCI_INITIALIZED(client->CALLBACK ## _callback)) { \
         zval_ptr_dtor(&client->CALLBACK ## _callback.function_name); \
     } \
  \
 	if (client->CALLBACK ## _callback.object_ptr != NULL) { \
 		zval_ptr_dtor(&client->CALLBACK ## _callback.object_ptr); \
-	}
-
+	} \
+	client->CALLBACK ## _callback = empty_fcall_info; \
+	client->CALLBACK ## _callback_cache = empty_fcall_info_cache;
+#endif
 
 #define PHP_MOSQUITTO_MESSAGE_PROPERTY_ENTRY_RECORD(name) \
 	{ "" #name "",		sizeof("" #name "") - 1,	php_mosquitto_message_read_##name,	php_mosquitto_message_write_##name }
@@ -113,13 +170,20 @@ typedef struct _php_mosquitto_prop_handler {
 	} \
 }
 
-#define PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_READER_FUNCTION(name) \
-	static int php_mosquitto_message_read_##name(mosquitto_message_object *mosquitto_object, zval **retval TSRMLS_DC) \
-	{ \
+#ifdef ZEND_ENGINE_3
+# define PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_READER_FUNCTION(name) \
+	static int php_mosquitto_message_read_##name(mosquitto_message_object *mosquitto_object, zval *retval) { \
+		ZVAL_LONG(retval, mosquitto_object->message.name); \
+		return SUCCESS; \
+	}
+#else
+# define PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_READER_FUNCTION(name) \
+	static int php_mosquitto_message_read_##name(mosquitto_message_object *mosquitto_object, zval **retval TSRMLS_DC) { \
 		MAKE_STD_ZVAL(*retval); \
 		ZVAL_LONG(*retval, mosquitto_object->message.name); \
 		return SUCCESS; \
 	}
+#endif
 
 #define PHP_MOSQUITTO_MESSAGE_LONG_PROPERTY_WRITER_FUNCTION(name) \
 static int php_mosquitto_message_write_##name(mosquitto_message_object *mosquitto_object, zval *newval TSRMLS_DC) \

--- a/tests/Client/connect.phpt
+++ b/tests/Client/connect.phpt
@@ -106,8 +106,8 @@ Mosquitto\Client::connect() expects at least 1 parameter, 0 given
 %s error.
 %s error.
 Invalid function arguments provided.
-Mosquitto\Client::connect() expects parameter 2 to be long, object given
-Mosquitto\Client::connect() expects parameter 3 to be long, object given
+Mosquitto\Client::connect() expects parameter 2 to be %s, object given
+Mosquitto\Client::connect() expects parameter 3 to be %s, object given
 %s error.
 object(Mosquitto\Client)#%d (%d) {
 }

--- a/tests/Client/onConnect.phpt
+++ b/tests/Client/onConnect.phpt
@@ -9,8 +9,10 @@ include(dirname(__DIR__) . '/setup.php');
 try {
     $client = new Mosquitto\Client;
     $client->onConnect('foo');
-} catch (Exception $e) {
+} catch (TypeError $e) {
     printf("Caught %s with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
+} catch (Mosquitto\Exception $e) {
+    printf("Caught TypeError with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
 }
 unset($client);
 
@@ -26,8 +28,7 @@ for ($i = 0; $i < 2; $i++) {
 }
 ?>
 --EXPECTF--
-Caught error 4096 (Argument 1 passed to Mosquitto\Client::onConnect() must be callable, string given) in %s on line 6
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::onConnect() expects parameter 1 to be a valid callback, function 'foo' not found or invalid function name
+%ACaught TypeError with code 0 and message: %s
 array(2) {
   [0]=>
   int(0)

--- a/tests/Client/onDisconnect.phpt
+++ b/tests/Client/onDisconnect.phpt
@@ -9,8 +9,10 @@ include(dirname(__DIR__) . '/setup.php');
 try {
     $client = new Mosquitto\Client;
     $client->onDisconnect('foo');
-} catch (Exception $e) {
+} catch (TypeError $e) {
     printf("Caught %s with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
+} catch (Mosquitto\Exception $e) {
+    printf("Caught TypeError with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
 }
 unset($client);
 
@@ -47,8 +49,7 @@ for ($i = 0; $i < 5; $i++) {
 
 ?>
 --EXPECTF--
-Caught error 4096 (Argument 1 passed to Mosquitto\Client::onDisconnect() must be callable, string given) in %s on line 6
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::onDisconnect() expects parameter 1 to be a valid callback, function 'foo' not found or invalid function name
+%ACaught TypeError with code 0 and message: %s
 Triggering disconnect
 Disconnected
 Disconnected

--- a/tests/Client/onLog.phpt
+++ b/tests/Client/onLog.phpt
@@ -13,8 +13,10 @@ function logger() {
 try {
     $client = new Mosquitto\Client;
     $client->onLog('foo');
-} catch (Exception $e) {
+} catch (TypeError $e) {
     printf("Caught %s with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
+} catch (Mosquitto\Exception $e) {
+    printf("Caught TypeError with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
 }
 
 $client = new Mosquitto\Client;
@@ -26,8 +28,7 @@ $client->loop(50);
 $client->loop(50);
 ?>
 --EXPECTF--
-Caught error 4096 (Argument 1 passed to Mosquitto\Client::onLog() must be callable, string given) in %s on line %d
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::onLog() expects parameter 1 to be a valid callback, function 'foo' not found or invalid function name
+%ACaught TypeError with code 0 and message: %s
 object(Mosquitto\Client)#%d (%d) {
 }
 array(2) {

--- a/tests/Client/onMessage.phpt
+++ b/tests/Client/onMessage.phpt
@@ -9,8 +9,10 @@ include(dirname(__DIR__) . '/setup.php');
 try {
     $client = new Mosquitto\Client;
     $client->onMessage('foo');
-} catch (Exception $e) {
+} catch (TypeError $e) {
     printf("Caught %s with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
+} catch (Mosquitto\Exception $e) {
+    printf("Caught TypeError with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
 }
 unset($client);
 
@@ -28,15 +30,14 @@ $client2 = new Mosquitto\Client;
 $client2->connect(TEST_MQTT_HOST);
 $client2->publish('test', 'test', 1);
 
-for ($i = 0; $i < 3; $i++) {
+for ($i = 0; $i < 30; $i++) {
     $client->loop(50);
     $client2->loop(50);
 }
 
 ?>
 --EXPECTF--
-Caught error 4096 (Argument 1 passed to Mosquitto\Client::onMessage() must be callable, string given) in %s on line %d
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::onMessage() expects parameter 1 to be a valid callback, function 'foo' not found or invalid function name
+%ACaught TypeError with code 0 and message: %s
 object(Mosquitto\Client)#%d (%d) {
 }
 object(Mosquitto\Message)#%d (%d) {

--- a/tests/Client/onSubscribe.phpt
+++ b/tests/Client/onSubscribe.phpt
@@ -9,8 +9,10 @@ include(dirname(__DIR__) . '/setup.php');
 try {
     $client = new Mosquitto\Client;
     $client->onSubscribe('foo');
-} catch (Exception $e) {
+} catch (TypeError $e) {
     printf("Caught %s with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
+} catch (Mosquitto\Exception $e) {
+    printf("Caught TypeError with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
 }
 unset($client);
 
@@ -29,8 +31,7 @@ $client->loopForever();
 
 ?>
 --EXPECTF--
-Caught error 4096 (Argument 1 passed to Mosquitto\Client::onSubscribe() must be callable, string given) in %s on line 6
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::onSubscribe() expects parameter 1 to be a valid callback, function 'foo' not found or invalid function name
+%ACaught TypeError with code 0 and message: %s
 array(3) {
   [0]=>
   int(1)

--- a/tests/Client/onUnsubscribe.phpt
+++ b/tests/Client/onUnsubscribe.phpt
@@ -9,8 +9,10 @@ include(dirname(__DIR__) . '/setup.php');
 try {
     $client = new Mosquitto\Client;
     $client->onUnsubscribe('foo');
-} catch (Exception $e) {
+} catch (TypeError $e) {
     printf("Caught %s with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
+} catch (Mosquitto\Exception $e) {
+    printf("Caught TypeError with code %d and message: %s\n", get_class($e), $e->getCode(), $e->getMessage());
 }
 unset($client);
 
@@ -34,8 +36,7 @@ $client->loopForever();
 
 ?>
 --EXPECTF--
-Caught error 4096 (Argument 1 passed to Mosquitto\Client::onUnsubscribe() must be callable, string given) in %s on line 6
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::onUnsubscribe() expects parameter 1 to be a valid callback, function 'foo' not found or invalid function name
+%ACaught TypeError with code 0 and message: %s
 array(3) {
   [0]=>
   int(1)

--- a/tests/Client/publish.phpt
+++ b/tests/Client/publish.phpt
@@ -114,7 +114,7 @@ Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() 
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() expects parameter 1 to be string, object given
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() expects at least 2 parameters, 1 given
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() expects at least 2 parameters, 1 given
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() expects parameter 3 to be long, object given
+Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() expects parameter 3 to be %s, object given
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::publish() expects parameter 4 to be boolean, object given
 Caught Mosquitto\Exception with code 0 and message: The client is not currently connected.
 Caught Mosquitto\Exception with code 0 and message: The client is not currently connected.

--- a/tests/Client/setMaxInFlightMessages.phpt
+++ b/tests/Client/setMaxInFlightMessages.phpt
@@ -37,5 +37,5 @@ object(Mosquitto\Client)#%d (0) {
 }
 object(Mosquitto\Client)#%d (0) {
 }
-string(87) "Mosquitto\Client::setMaxInFlightMessages() expects parameter 1 to be long, string given"
-string(87) "Mosquitto\Client::setMaxInFlightMessages() expects parameter 1 to be long, object given"
+string(%d) "Mosquitto\Client::setMaxInFlightMessages() expects parameter 1 to be %s, string given"
+string(%d) "Mosquitto\Client::setMaxInFlightMessages() expects parameter 1 to be %s, object given"

--- a/tests/Client/setMessageRetry.phpt
+++ b/tests/Client/setMessageRetry.phpt
@@ -37,5 +37,5 @@ object(Mosquitto\Client)#%d (0) {
 }
 object(Mosquitto\Client)#%d (0) {
 }
-string(80) "Mosquitto\Client::setMessageRetry() expects parameter 1 to be long, string given"
-string(80) "Mosquitto\Client::setMessageRetry() expects parameter 1 to be long, object given"
+string(%d) "Mosquitto\Client::setMessageRetry() expects parameter 1 to be %s, string given"
+string(%d) "Mosquitto\Client::setMessageRetry() expects parameter 1 to be %s, object given"

--- a/tests/Client/setReconnectDelay.phpt
+++ b/tests/Client/setReconnectDelay.phpt
@@ -37,5 +37,5 @@ object(Mosquitto\Client)#%d (0) {
 }
 object(Mosquitto\Client)#%d (0) {
 }
-string(82) "Mosquitto\Client::setReconnectDelay() expects parameter 1 to be long, string given"
-string(82) "Mosquitto\Client::setReconnectDelay() expects parameter 1 to be long, object given"
+string(%d) "Mosquitto\Client::setReconnectDelay() expects parameter 1 to be %s, string given"
+string(%d) "Mosquitto\Client::setReconnectDelay() expects parameter 1 to be %s, object given"

--- a/tests/Client/setTlsOptions.phpt
+++ b/tests/Client/setTlsOptions.phpt
@@ -38,7 +38,7 @@ $client->setTlsOptions(Mosquitto\Client::SSL_VERIFY_PEER, 'tlsv1.2', 'DEFAULT');
 ?>
 --EXPECTF--
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::setTlsOptions() expects at least 1 parameter, 0 given
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::setTlsOptions() expects parameter 1 to be long, object given
+Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::setTlsOptions() expects parameter 1 to be %s, object given
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::setTlsOptions() expects parameter 2 to be string, object given
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::setTlsOptions() expects parameter 3 to be string, object given
 

--- a/tests/Client/subscribe.phpt
+++ b/tests/Client/subscribe.phpt
@@ -73,7 +73,7 @@ Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::subscribe(
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::subscribe() expects exactly 2 parameters, 1 given
 Caught Mosquitto\Exception with code 0 and message: The client is not currently connected.
 Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::subscribe() expects parameter 1 to be string, object given
-Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::subscribe() expects parameter 2 to be long, object given
+Caught Mosquitto\Exception with code 0 and message: Mosquitto\Client::subscribe() expects parameter 2 to be %s, object given
 array(3) {
   [0]=>
   int(%d)

--- a/tests/Message/__construct.phpt
+++ b/tests/Message/__construct.phpt
@@ -77,8 +77,7 @@ object(Mosquitto\Message)#1 (5) {
   bool(false)
 }
 Caught error 4096 (Object of class stdClass could not be converted to string) in %s on line 16
-Caught error 8 (Object of class stdClass to string conversion) in %s on line 16
-object(Mosquitto\Message)#1 (5) {
+%Aobject(Mosquitto\Message)#1 (5) {
   ["mid"]=>
   int(%d)
   ["topic"]=>
@@ -103,8 +102,7 @@ object(Mosquitto\Message)#1 (5) {
   bool(false)
 }
 Caught error 4096 (Object of class stdClass could not be converted to string) in %s on line 22
-Caught error 8 (Object of class stdClass to string conversion) in %s on line 22
-object(Mosquitto\Message)#1 (5) {
+%Aobject(Mosquitto\Message)#1 (5) {
   ["mid"]=>
   int(%d)
   ["topic"]=>

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -2,6 +2,11 @@
 
 define('CERTIFICATE_DIR', __DIR__ . '/certs/');
 
+if (!class_exists("TypeError")) {
+  // Hack for PHP7 throwing type mismatches as TypeErrors rather than Mosquito\Exception
+  class TypeError extends Exception {}
+}
+
 $defaults = array(
     'TEST_MQTT_HOST' => 'localhost',
     'TEST_MQTT_PORT' => 1883,


### PR DESCRIPTION
Retains PHP5 compat through several ifdef checks for ZEND_ENGINE_2/ZEND_ENGINE_3
When we're ready to drop PHP5 support, this code can be cleaned up noticably.